### PR TITLE
upgrade Prometheus simple-client to 0.9.0

### DIFF
--- a/metrics-reporter-prometheus/pom.xml
+++ b/metrics-reporter-prometheus/pom.xml
@@ -18,7 +18,7 @@
     <description>Plugin for reporting internal Graylog metrics to Prometheus.</description>
 
     <properties>
-        <simpleclient.version>0.3.0</simpleclient.version>
+        <simpleclient.version>0.9.0</simpleclient.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Former version of prometheus client generates excpetions with push gateway 0.10.0+ due to response code mismatch:
https://github.com/prometheus/client_java/commit/ddf03f1a939d7c41659bdf7b4a150657ffa5cadb